### PR TITLE
added pr testing and scorecard

### DIFF
--- a/.github/workflows/pr-operator.yml
+++ b/.github/workflows/pr-operator.yml
@@ -34,6 +34,11 @@ on:
         default: false
         required: false
         type: boolean
+      CHECKOUT_CODE:
+        description: "Repository to checkout"
+        default: "${{ github.repository }}"
+        required: false
+        type: string
 env:
   DEFAULT_BUNDLE_VERSION: "0.0.1"
   DEFAULT_BUNDLE_CHANNEL: "alpha"
@@ -46,18 +51,26 @@ jobs:
     runs-on: ubuntu-latest
     name: setup
     steps:
+      - name: Check out code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          repository: ${{ inputs.CHECKOUT_CODE }}
+          
       - name: Setting Workflow Variables
         id: set-variables
         env:
           BUILD_PLATFORMS: ${{ inputs.BUILD_PLATFORMS }}
+          CHECKOUT_CODE: ${{ inputs.CHECKOUT_CODE }}
         run: |
-          echo "repository_name=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_OUTPUT
+          echo "repository_name=$(basename ${{ env.CHECKOUT_CODE }})" >> $GITHUB_OUTPUT
           echo "bin_dir=$(pwd)/bin" >> $GITHUB_OUTPUT
 
           # Create Distribution Matrix
           echo "dist_matrix=$(echo -n "${{ env.BUILD_PLATFORMS }}" | jq -csR '. | split(",")')" >> $GITHUB_OUTPUT
           # Create Image Tags
           echo "image_platform_tags=$(echo $BUILD_PLATFORMS | sed  -e 's/,/ /g' -e 's/\//-/g')" >> $GITHUB_OUTPUT
+          
+          echo "$(cat ${GITHUB_OUTPUT})"
 
       - name: Setting Image Variables
         id: set-variables-image
@@ -94,6 +107,8 @@ jobs:
             echo "bundle_version=$DEFAULT_BUNDLE_VERSION" >> $GITHUB_OUTPUT
             echo "helmchart_version=$DEFAULT_HELMCHART_VERSION" >> $GITHUB_OUTPUT
           fi
+          
+          echo "$(cat ${GITHUB_OUTPUT})"
 
       - name: Verify Semver Bundle Version
         uses: rubenesp87/semver-validation-action@8f4b9f2835a4826fbbdfe8f5dbb6ad8996cf5831 # 0.1.0
@@ -116,9 +131,6 @@ jobs:
         with:
           go-version: ${{ inputs.GO_VERSION }}
           cache: false
-
-      - name: Check out code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Go Build Cache
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
@@ -195,6 +207,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          repository: ${{ inputs.CHECKOUT_CODE }}
 
       - name: Go Build Cache
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
@@ -325,6 +339,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          repository: ${{ inputs.CHECKOUT_CODE }}
 
       - name: Go Build Cache
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
@@ -447,6 +463,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          repository: ${{ inputs.CHECKOUT_CODE }}
 
       - name: Go Build Cache
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
@@ -479,7 +497,7 @@ jobs:
         shell: bash
         run: |
           # Render Helm Chart
-          make helmchart VERSION=${{ env.HELM_RELEASE_VERSION }} IMG=${{ env.OPERATOR_IMAGE_REPOSITORY }}:${{ env.OPERATOR_VERSION }}
+          make helmchart OPERATOR_NAME=${{ env.REPOSITORY_NAME }} VERSION=${{ env.HELM_RELEASE_VERSION }} IMG=${{ env.OPERATOR_IMAGE_REPOSITORY }}:${{ env.OPERATOR_VERSION }}
 
           # Package Helm Chart
           mkdir dist
@@ -507,6 +525,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          repository: ${{ inputs.CHECKOUT_CODE }}
 
       - name: Go Build Cache
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
@@ -564,6 +584,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          repository: ${{ inputs.CHECKOUT_CODE }}
 
       - name: Go Build Cache
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
@@ -594,4 +616,4 @@ jobs:
 
       - name: Test Helm Chart Deployment
         shell: bash
-        run: make helmchart-test
+        run: make helmchart-test OPERATOR_NAME=${{ env.REPOSITORY_NAME }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,60 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '36 19 * * 3'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3.27.5
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/test-group-sync-operator.yaml
+++ b/.github/workflows/test-group-sync-operator.yaml
@@ -1,0 +1,24 @@
+name: Testing group-sync-operator
+on:
+  pull_request:
+  schedule:
+    - cron: '0 1 * * 1'
+
+# Declare default permissions as read only.
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  group-sync-operator-workflow:
+    name: Test PR shared-operator-workflow for group-sync-operator
+    uses: ./.github/workflows/pr-operator.yml
+    with:
+      GO_VERSION: ~1.21
+      RUN_UNIT_TESTS: true
+      RUN_INTEGRATION_TESTS: false
+      RUN_HELMCHART_TEST: false
+      OPERATOR_SDK_VERSION: v1.25.2
+      CHECKOUT_CODE: "redhat-cop/group-sync-operator"

--- a/.github/workflows/test-namespace-configuration-operator.yaml
+++ b/.github/workflows/test-namespace-configuration-operator.yaml
@@ -1,0 +1,24 @@
+name: Testing namespace-configuration-operator
+on:
+  pull_request:
+  schedule:
+    - cron: '0 1 * * 1'
+
+# Declare default permissions as read only.
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  namespace-configuration-operator-workflow:
+    name: Test PR shared-operator-workflow for namespace-configuration-operator
+    uses: ./.github/workflows/pr-operator.yml
+    with:
+      RUN_UNIT_TESTS: true
+      RUN_INTEGRATION_TESTS: true
+      RUN_HELMCHART_TEST: true
+      GO_VERSION: ~1.21
+      OPERATOR_SDK_VERSION: v1.31.0
+      CHECKOUT_CODE: "redhat-cop/namespace-configuration-operator"

--- a/.github/workflows/test-patch-operator.yaml
+++ b/.github/workflows/test-patch-operator.yaml
@@ -1,0 +1,24 @@
+name: Testing patch-operator
+on:
+  pull_request:
+  schedule:
+    - cron: '0 1 * * 1'
+
+# Declare default permissions as read only.
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  patch-operator-workflow:
+    name: Test PR shared-operator-workflow for patch-operator
+    uses: ./.github/workflows/pr-operator.yml
+    with:
+      RUN_UNIT_TESTS: true
+      RUN_INTEGRATION_TESTS: false
+      RUN_HELMCHART_TEST: true
+      GO_VERSION: ~1.21
+      OPERATOR_SDK_VERSION: v1.23.0
+      CHECKOUT_CODE: "redhat-cop/patch-operator"

--- a/.github/workflows/test-vault-config-operator.yaml
+++ b/.github/workflows/test-vault-config-operator.yaml
@@ -1,0 +1,24 @@
+name: Testing vault-config-operator
+on:
+  pull_request:
+  schedule:
+    - cron: '0 1 * * 1'
+
+# Declare default permissions as read only.
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
+jobs:
+  vault-config-operator-workflow:
+    name: Test PR shared-operator-workflow for vault-config-operator
+    uses: ./.github/workflows/pr-operator.yml
+    with:
+      RUN_UNIT_TESTS: true
+      RUN_INTEGRATION_TESTS: true
+      RUN_HELMCHART_TEST: true
+      GO_VERSION: ~1.21
+      OPERATOR_SDK_VERSION: v1.25.3
+      CHECKOUT_CODE: "redhat-cop/vault-config-operator"


### PR DESCRIPTION
Any PRs to the workflows in this repo have to be manually tested outside of the repo. I've done this by changing a consumer repo (i.e.: redhat-cop/group-sync-operator) to use the new version of my fork.

This change adds the ability to run the PR workflow against `redhat-cop/group-sync-operator`, improving confidence any changes to the PR workflow are OK and will at least work against `redhat-cop/group-sync-operator`

The new `input` is to allow the workflow to work against another repo, since this one doesn't contain any code.